### PR TITLE
avoid Meteor error when createDeepstream

### DIFF
--- a/client/watch.js
+++ b/client/watch.js
@@ -387,13 +387,13 @@ Template.watch_page.onRendered(function(){
 
   this.mainPlayerYTApiActivated = false;
   this.mainPlayerUSApiActivated = false;
-  
-  this.checkTime = Meteor.setInterval(()=>{
+
+  this.checkTime = setInterval(() => {
     if(mainPlayer && mainPlayer.getElapsedTime){
       Session.set('currentTimeElapsed', mainPlayer.getElapsedTime());
     }
-  }.bind(this),4000);
-  
+  }, 4000);
+
   // activate jsAPIs for main stream
   this.autorun(function(){
     if(ytApiReady.get() && FlowRouter.subsReady()){


### PR DESCRIPTION
avoid “cannot set timers inside of simulations” which blocks the rest of the watch_page.onRendered function.
